### PR TITLE
Build pdf

### DIFF
--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -18,6 +18,8 @@
 from __future__ import annotations
 
 import argparse
+import ROOT, uproot
+from legendmeta import LegendMetadata
 
 parser = argparse.ArgumentParser(
     prog="build_pdf", description="build LEGEND pdf files from evt tier files"
@@ -28,7 +30,86 @@ parser.add_argument("input_files", nargs="+", help="evt tier files")
 
 args = parser.parse_args()
 
+meta = LegendMetadata(args.metadata)
+chmap = meta.channelmap("20230323T000000Z")
+
 if not isinstance(args.input_files, list):
     args.input_files = [args.input_files]
 
 # TODO: move build_pdf script here
+
+def process_mage_id(mage_id, chmap):
+    m_id = str(mage_id)
+    is_ged = bool(int(m_id[0]))
+    if not is_ged:
+        return False
+
+    string = int(m_id[3:5])
+    pos = int(m_id[5:7])
+
+    for key, value in chmap.items():
+        if isinstance(value, dict) and 'location' in value:
+            location = value['location']
+            if location.get('string') == string and location.get('position') == pos:
+                return {'name': key, 'ch': value['daq']['rawid'], 'mage_id': mage_id}
+
+    return False
+
+# Get the tree from the file 
+file = ROOT.TFile(args.input_files[0], "READ")
+tree = file.Get('simTree')
+# Can also access wihtout tree name
+# Tobject = file.GetListOfKeys().At(0).ReadObj() # This assumes that there is only one object in the file
+
+uniq_mage_ids = list(set([mage_id for n in [list(tree.mage_id) for entry in tree] for mage_id in n]))
+mage_names = {mage_id : process_mage_id(mage_id, chmap) for mage_id in uniq_mage_ids if process_mage_id(mage_id, chmap)}
+    
+# Set up the root output file
+#if args.output_file == './':
+#    output_file = args.input_file.split('.')[0] + '_pdf.root'
+        
+out_file = uproot.create(args.output)
+
+# list of cuts
+cuts = {
+    'raw': '',
+    'mul': 'mage_id@.size()==1',
+    'lar': 'npe_tot==0',
+    'mul_lar': 'mage_id@.size()==1 && npe_tot==0'
+}
+
+for cut_name, cut_string in cuts.items():
+    dir = out_file.mkdir(cut_name)
+
+    # Define the grouped histos to be updated 
+    grouped = {
+        f'{i}': ROOT.TH1D(
+                f'hist_{cut_name}_{i}',
+                f'{i} energy deposit',
+                3000, 0, 3
+            ) for i in ['bege', 'coax', 'icpc', 'ppc']
+    }
+
+    # loop over the channels
+    for mage_id, mg_dict in mage_names.items():
+        if cut_string == '': 
+            string = f'mage_id=={mage_id}'
+        else:
+            string = f'mage_id=={mage_id} && {cut_string}'
+            
+        hist = ROOT.TH1D(f'hist_{cut_name}_{mg_dict["ch"]}', f'{mg_dict["name"]} energy deposit', 3000, 0, 3) # units of MeV and bin width of 1keV
+        tree.Project(hist.GetName(), 'energy', string) # add cut
+        dir[hist.GetName()] = hist
+
+        tree.Project(grouped[chmap[mg_dict["name"]]['type']].GetName(), 'energy', string)
+
+    for ged_type, hist in grouped.items():
+       dir[hist.GetName()] = hist 
+
+    # Then finally ALL
+    hist = ROOT.TH1D(f'hist_{cut_name}_all', 'All channels energy deposit', 3000, 0, 3) # units of MeV and bin width of 1keV
+    tree.Project(hist.GetName(), 'energy', cut_string) # add cut
+    dir[hist.GetName()] = hist
+
+out_file.close()
+file.Close()

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -18,7 +18,9 @@
 from __future__ import annotations
 
 import argparse
-import ROOT, uproot
+
+import ROOT
+import uproot
 from legendmeta import LegendMetadata
 
 parser = argparse.ArgumentParser(
@@ -36,6 +38,7 @@ chmap = meta.channelmap("20230323T000000Z")
 if not isinstance(args.input_files, list):
     args.input_files = [args.input_files]
 
+
 def process_mage_id(mage_id, chmap):
     m_id = str(mage_id)
     is_ged = bool(int(m_id[0]))
@@ -46,69 +49,76 @@ def process_mage_id(mage_id, chmap):
     pos = int(m_id[5:7])
 
     for key, value in chmap.items():
-        if isinstance(value, dict) and 'location' in value:
-            location = value['location']
-            if location.get('string') == string and location.get('position') == pos:
-                return {'name': key, 'ch': value['daq']['rawid'], 'mage_id': mage_id}
+        if isinstance(value, dict) and "location" in value:
+            location = value["location"]
+            if location.get("string") == string and location.get("position") == pos:
+                return {"name": key, "ch": value["daq"]["rawid"], "mage_id": mage_id}
 
     return False
+
 
 # TODO: Do we need a config file?
 # list of cuts - this could / should be moved to a config file
 # Could also include the bins and widths
 cuts = {
-    'raw': '',
-    'mul': 'mage_id@.size()==1',
-    'lar': 'npe_tot==0',
-    'mul_lar': 'mage_id@.size()==1 && npe_tot==0'
+    "raw": "",
+    "mul": "mage_id@.size()==1",
+    "lar": "npe_tot==0",
+    "mul_lar": "mage_id@.size()==1 && npe_tot==0",
 }
 
 for file_name in args.input_files:
-
-    # Get the tree from the file 
+    # Get the tree from the file
     file = ROOT.TFile(file_name, "READ")
-    tree = file.Get('simTree')
-    
-    uniq_mage_ids = list(set([mage_id for n in [list(tree.mage_id) for entry in tree] for mage_id in n]))
-    mage_names = {mage_id : process_mage_id(mage_id, chmap) for mage_id in uniq_mage_ids if process_mage_id(mage_id, chmap)}
+    tree = file.Get("simTree")
 
-    out_file_name = file_name.split('/')[-1].split(".")[0] + '_pdf' + '.root'   
+    uniq_mage_ids = list(
+        {mage_id for n in [list(tree.mage_id) for entry in tree] for mage_id in n}
+    )
+    mage_names = {
+        mage_id: process_mage_id(mage_id, chmap)
+        for mage_id in uniq_mage_ids
+        if process_mage_id(mage_id, chmap)
+    }
+
+    out_file_name = file_name.split("/")[-1].split(".")[0] + "_pdf" + ".root"
     out_file = uproot.create(args.output + out_file_name)
 
     for cut_name, cut_string in cuts.items():
         dir = out_file.mkdir(cut_name)
 
-        # Define the grouped histos to be updated 
+        # Define the grouped histos to be updated
         geds_dict = {
-            f'{i}': ROOT.TH1D(
-                    f'type_{i}',
-                    f'All {i} energy deposit',
-                    3000, 0, 3
-                ) for i in ['bege', 'coax', 'icpc', 'ppc']
+            f"{i}": ROOT.TH1D(f"type_{i}", f"All {i} energy deposit", 3000, 0, 3)
+            for i in ["bege", "coax", "icpc", "ppc"]
         }
 
         # loop over the channels
         for mage_id, mg_dict in mage_names.items():
-            if cut_string == '': 
-                string = f'mage_id=={mage_id}'
+            if cut_string == "":
+                string = f"mage_id=={mage_id}"
             else:
-                string = f'mage_id=={mage_id} && {cut_string}'
+                string = f"mage_id=={mage_id} && {cut_string}"
 
-            hist = ROOT.TH1D(f'ch{mg_dict["ch"]}', f'{mg_dict["name"]} energy deposit', 3000, 0, 3) # units of MeV and bin width of 1keV
-            tree.Project(hist.GetName(), 'energy', string) # add cut
+            hist = ROOT.TH1D(
+                f'ch{mg_dict["ch"]}', f'{mg_dict["name"]} energy deposit', 3000, 0, 3
+            )  # units of MeV and bin width of 1keV
+            tree.Project(hist.GetName(), "energy", string)  # add cut
             dir[hist.GetName()] = hist
 
-            geds_dict[chmap[mg_dict["name"]]['type']].Add(hist)
+            geds_dict[chmap[mg_dict["name"]]["type"]].Add(hist)
 
             del hist
 
-        for ged_type, hist in geds_dict.items():
-            dir[hist.GetName()] = hist 
+        for _ged_type, hist in geds_dict.items():
+            dir[hist.GetName()] = hist
         del geds_dict
 
         # Then finally ALL
-        hist = ROOT.TH1D(f'all', 'All channels energy deposit', 3000, 0, 3) # units of MeV and bin width of 1keV
-        tree.Project(hist.GetName(), 'energy', cut_string) # add cut
+        hist = ROOT.TH1D(
+            "all", "All channels energy deposit", 3000, 0, 3
+        )  # units of MeV and bin width of 1keV
+        tree.Project(hist.GetName(), "energy", cut_string)  # add cut
         dir[hist.GetName()] = hist
         del hist
 

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -89,7 +89,7 @@ for file_name in args.input_files:
 
         # Define the grouped histos to be updated
         geds_dict = {
-            f"{i}": ROOT.TH1D(f"type_{i}", f"All {i} energy deposit", 3000, 0, 3)
+            f"{i}": ROOT.TH1D(f"type_{i}", f"All {i} energy deposit", 3000, 0, 3000)
             for i in ["bege", "coax", "icpc", "ppc"]
         }
 
@@ -101,9 +101,9 @@ for file_name in args.input_files:
                 string = f"mage_id=={mage_id} && {cut_string}"
 
             hist = ROOT.TH1D(
-                f'ch{mg_dict["ch"]}', f'{mg_dict["name"]} energy deposit', 3000, 0, 3
-            )  # units of MeV and bin width of 1keV
-            tree.Project(hist.GetName(), "energy", string)  # add cut
+                f'ch{mg_dict["ch"]}', f'{mg_dict["name"]} energy deposit', 3000, 0, 3000
+            )  # units of keV and bin width of 1keV
+            tree.Project(hist.GetName(), "energy * 1000", string)  # add cut
             dir[hist.GetName()] = hist
 
             geds_dict[chmap[mg_dict["name"]]["type"]].Add(hist)
@@ -116,9 +116,9 @@ for file_name in args.input_files:
 
         # Then finally ALL
         hist = ROOT.TH1D(
-            "all", "All channels energy deposit", 3000, 0, 3
-        )  # units of MeV and bin width of 1keV
-        tree.Project(hist.GetName(), "energy", cut_string)  # add cut
+            "all", "All channels energy deposit", 3000, 0, 3000
+        )  # units of keV and bin width of 1keV
+        tree.Project(hist.GetName(), "energy * 1000", cut_string)  # add cut
         dir[hist.GetName()] = hist
         del hist
 

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -18,10 +18,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 
 import ROOT
 import uproot
-import json
 from legendmeta import LegendMetadata
 
 parser = argparse.ArgumentParser(
@@ -41,6 +41,7 @@ if not isinstance(args.input_files, list):
 
 rconfig = json.load(open("build_pdf_config.json"))
 
+
 def process_mage_id(mage_id):
     m_id = str(mage_id)
     is_ged = bool(int(m_id[0]))
@@ -53,14 +54,18 @@ def process_mage_id(mage_id):
     for key, value in chmap.items():
         if isinstance(value, dict) and "location" in value:
             location = value["location"]
-            usable = value['analysis']["usability"]=='on' 
-            if location.get("string") == string and location.get("position") == pos and usable:
+            usable = value["analysis"]["usability"] == "on"
+            if (
+                location.get("string") == string
+                and location.get("position") == pos
+                and usable
+            ):
                 return {"name": key, "ch": value["daq"]["rawid"], "mage_id": mage_id}
 
     return False
 
-for file_name in args.input_files:
 
+for file_name in args.input_files:
     # Get the tree from the file
     file = ROOT.TFile(file_name, "READ")
     tree = file.Get("simTree")
@@ -79,22 +84,33 @@ for file_name in args.input_files:
     hists = {
         f"{cut_name}": {
             _mage_id: ROOT.TH1F(
-                    f"{cut_name}_{_mage_names['ch']}", f"{_mage_names['name']} energy deposition",
-                    rconfig['hist']['nbins'], rconfig['hist']['emin'], rconfig['hist']['emax']
-                ) for _mage_id, _mage_names in mage_names.items()
-        } for cut_name in rconfig["cuts"].keys()
+                f"{cut_name}_{_mage_names['ch']}",
+                f"{_mage_names['name']} energy deposition",
+                rconfig["hist"]["nbins"],
+                rconfig["hist"]["emin"],
+                rconfig["hist"]["emax"],
+            )
+            for _mage_id, _mage_names in mage_names.items()
+        }
+        for cut_name in rconfig["cuts"]
     }
     # Add the grouped dets hists
-    for cut_name in rconfig["cuts"].keys():
+    for cut_name in rconfig["cuts"]:
         for _type in ["bege", "coax", "icpc", "ppc"]:
-            hists[cut_name][f"{_type}"] = ROOT.TH1F( 
-                f"{cut_name}_type_{_type}", f"All {_type} energy deposit",
-                    rconfig['hist']['nbins'], rconfig['hist']['emin'], rconfig['hist']['emax']
-            ) 
-        hists[cut_name]['all'] = ROOT.TH1F( 
-            f"{cut_name}_type_all", f"All energy deposit",
-            rconfig['hist']['nbins'], rconfig['hist']['emin'], rconfig['hist']['emax']
-        ) 
+            hists[cut_name][f"{_type}"] = ROOT.TH1F(
+                f"{cut_name}_type_{_type}",
+                f"All {_type} energy deposit",
+                rconfig["hist"]["nbins"],
+                rconfig["hist"]["emin"],
+                rconfig["hist"]["emax"],
+            )
+        hists[cut_name]["all"] = ROOT.TH1F(
+            f"{cut_name}_type_all",
+            "All energy deposit",
+            rconfig["hist"]["nbins"],
+            rconfig["hist"]["emin"],
+            rconfig["hist"]["emax"],
+        )
 
     out_file_name = file_name.split("/")[-1].split(".")[0] + "_pdf" + ".root"
     out_file = uproot.recreate(args.output + out_file_name)
@@ -102,32 +118,40 @@ for file_name in args.input_files:
     # Loop over the data ONCE and fill as we go along
     for entry in tree:
         # In the real data we have an energy threshold defined in the config
-        energy_list  = [val for val in entry.energy if val >= rconfig['energy_threshold']]
-        mage_id_list = [val for index, val in enumerate(entry.mage_id) if entry.energy[index] >= rconfig['energy_threshold']]
+        energy_list = [
+            val for val in entry.energy if val >= rconfig["energy_threshold"]
+        ]
+        mage_id_list = [
+            val
+            for index, val in enumerate(entry.mage_id)
+            if entry.energy[index] >= rconfig["energy_threshold"]
+        ]
         npe_tot = entry.npe_tot
-        if len(energy_list) == 0: continue  # Nothing to fill
+        if len(energy_list) == 0:
+            continue  # Nothing to fill
 
         for cut_name, cut_string in rconfig["cuts"].items():
-
             # In the config is a lambda function string that returns true or false for each cut
             # Maybe this is too much but it allows for more cuts possibly
             exec(cut_string)
             pass_cut = func(energy_list, mage_id_list, npe_tot)
-            if not bool(pass_cut): continue
+            if not bool(pass_cut):
+                continue
 
             for mage_id, energy in zip(mage_id_list, energy_list):
                 energy_kev = energy * 1000
                 mage_dict = process_mage_id(mage_id)
 
-                if mage_dict == False: continue # not an 'on' detector so we don't fill
+                if mage_dict is False:
+                    continue  # not an 'on' detector so we don't fill
                 hists[cut_name][mage_id].Fill(energy_kev)
                 hists[cut_name][chmap[mage_dict["name"]]["type"]].Fill(energy_kev)
-                hists[cut_name]['all'].Fill(energy_kev)
+                hists[cut_name]["all"].Fill(energy_kev)
 
     # Create a new root file with the directories
-    for cut_name in rconfig["cuts"].keys():
+    for cut_name in rconfig["cuts"]:
         dir = out_file.mkdir(cut_name)
-        for key, item in hists[cut_name].items():
+        for _key, item in hists[cut_name].items():
             dir[item.GetName()] = item
 
     out_file.close()

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -21,6 +21,7 @@ import argparse
 
 import ROOT
 import uproot
+import json
 from legendmeta import LegendMetadata
 
 parser = argparse.ArgumentParser(
@@ -38,8 +39,9 @@ chmap = meta.channelmap("20230323T000000Z")
 if not isinstance(args.input_files, list):
     args.input_files = [args.input_files]
 
+rconfig = json.load(open("build_pdf_config.json"))
 
-def process_mage_id(mage_id, chmap):
+def process_mage_id(mage_id):
     m_id = str(mage_id)
     is_ged = bool(int(m_id[0]))
     if not is_ged:
@@ -51,23 +53,14 @@ def process_mage_id(mage_id, chmap):
     for key, value in chmap.items():
         if isinstance(value, dict) and "location" in value:
             location = value["location"]
-            if location.get("string") == string and location.get("position") == pos:
+            usable = value['analysis']["usability"]=='on' 
+            if location.get("string") == string and location.get("position") == pos and usable:
                 return {"name": key, "ch": value["daq"]["rawid"], "mage_id": mage_id}
 
     return False
 
-
-# TODO: Do we need a config file?
-# list of cuts - this could / should be moved to a config file
-# Could also include the bins and widths
-cuts = {
-    "raw": "",
-    "mul": "mage_id@.size()==1",
-    "lar": "npe_tot==0",
-    "mul_lar": "mage_id@.size()==1 && npe_tot==0",
-}
-
 for file_name in args.input_files:
+
     # Get the tree from the file
     file = ROOT.TFile(file_name, "READ")
     tree = file.Get("simTree")
@@ -76,51 +69,66 @@ for file_name in args.input_files:
         {mage_id for n in [list(tree.mage_id) for entry in tree] for mage_id in n}
     )
     mage_names = {
-        mage_id: process_mage_id(mage_id, chmap)
+        mage_id: process_mage_id(mage_id)
         for mage_id in uniq_mage_ids
-        if process_mage_id(mage_id, chmap)
+        if process_mage_id(mage_id)
     }
 
+    # Define a dictionary to contain all the histograms to be filled
+    # for each cut and each detector
+    hists = {
+        f"{cut_name}": {
+            _mage_id: ROOT.TH1F(
+                    f"{cut_name}_{_mage_names['ch']}", f"{_mage_names['name']} energy deposition",
+                    rconfig['hist']['nbins'], rconfig['hist']['emin'], rconfig['hist']['emax']
+                ) for _mage_id, _mage_names in mage_names.items()
+        } for cut_name in rconfig["cuts"].keys()
+    }
+    # Add the grouped dets hists
+    for cut_name in rconfig["cuts"].keys():
+        for _type in ["bege", "coax", "icpc", "ppc"]:
+            hists[cut_name][f"{_type}"] = ROOT.TH1F( 
+                f"{cut_name}_type_{_type}", f"All {_type} energy deposit",
+                    rconfig['hist']['nbins'], rconfig['hist']['emin'], rconfig['hist']['emax']
+            ) 
+        hists[cut_name]['all'] = ROOT.TH1F( 
+            f"{cut_name}_type_all", f"All energy deposit",
+            rconfig['hist']['nbins'], rconfig['hist']['emin'], rconfig['hist']['emax']
+        ) 
+
     out_file_name = file_name.split("/")[-1].split(".")[0] + "_pdf" + ".root"
-    out_file = uproot.create(args.output + out_file_name)
+    out_file = uproot.recreate(args.output + out_file_name)
 
-    for cut_name, cut_string in cuts.items():
+    # Loop over the data ONCE and fill as we go along
+    for entry in tree:
+        # In the real data we have an energy threshold defined in the config
+        energy_list  = [val for val in entry.energy if val >= rconfig['energy_threshold']]
+        mage_id_list = [val for index, val in enumerate(entry.mage_id) if entry.energy[index] >= rconfig['energy_threshold']]
+        npe_tot = entry.npe_tot
+        if len(energy_list) == 0: continue  # Nothing to fill
+
+        for cut_name, cut_string in rconfig["cuts"].items():
+
+            # In the config is a lambda function string that returns true or false for each cut
+            # Maybe this is too much but it allows for more cuts possibly
+            exec(cut_string)
+            pass_cut = func(energy_list, mage_id_list, npe_tot)
+            if not bool(pass_cut): continue
+
+            for mage_id, energy in zip(mage_id_list, energy_list):
+                energy_kev = energy * 1000
+                mage_dict = process_mage_id(mage_id)
+
+                if mage_dict == False: continue # not an 'on' detector so we don't fill
+                hists[cut_name][mage_id].Fill(energy_kev)
+                hists[cut_name][chmap[mage_dict["name"]]["type"]].Fill(energy_kev)
+                hists[cut_name]['all'].Fill(energy_kev)
+
+    # Create a new root file with the directories
+    for cut_name in rconfig["cuts"].keys():
         dir = out_file.mkdir(cut_name)
-
-        # Define the grouped histos to be updated
-        geds_dict = {
-            f"{i}": ROOT.TH1D(f"type_{i}", f"All {i} energy deposit", 3000, 0, 3000)
-            for i in ["bege", "coax", "icpc", "ppc"]
-        }
-
-        # loop over the channels
-        for mage_id, mg_dict in mage_names.items():
-            if cut_string == "":
-                string = f"mage_id=={mage_id}"
-            else:
-                string = f"mage_id=={mage_id} && {cut_string}"
-
-            hist = ROOT.TH1D(
-                f'ch{mg_dict["ch"]}', f'{mg_dict["name"]} energy deposit', 3000, 0, 3000
-            )  # units of keV and bin width of 1keV
-            tree.Project(hist.GetName(), "energy * 1000", string)  # add cut
-            dir[hist.GetName()] = hist
-
-            geds_dict[chmap[mg_dict["name"]]["type"]].Add(hist)
-
-            del hist
-
-        for _ged_type, hist in geds_dict.items():
-            dir[hist.GetName()] = hist
-        del geds_dict
-
-        # Then finally ALL
-        hist = ROOT.TH1D(
-            "all", "All channels energy deposit", 3000, 0, 3000
-        )  # units of keV and bin width of 1keV
-        tree.Project(hist.GetName(), "energy * 1000", cut_string)  # add cut
-        dir[hist.GetName()] = hist
-        del hist
+        for key, item in hists[cut_name].items():
+            dir[item.GetName()] = item
 
     out_file.close()
     file.Close()

--- a/scripts/build_pdf_config.json
+++ b/scripts/build_pdf_config.json
@@ -1,15 +1,15 @@
 {
-    "energy_threshold": 0.025,
-    "hist": {
-        "nbins": 3000,
-        "bin_width": 1,
-        "emin": 0,
-        "emax": 3000
-    },
-    "cuts": {
-        "raw":      "func = lambda energy_list, mage_id_list, npe_tot: True",
-        "mul":      "func = lambda energy_list, mage_id_list, npe_tot: len(energy_list)==1",
-        "lar":      "func = lambda energy_list, mage_id_list, npe_tot: npe_tot == 0",
-        "mul_lar" : "func = lambda energy_list, mage_id_list, npe_tot: npe_tot == 0 and len(energy_list)==1"
-    }
+  "energy_threshold": 0.025,
+  "hist": {
+    "nbins": 3000,
+    "bin_width": 1,
+    "emin": 0,
+    "emax": 3000
+  },
+  "cuts": {
+    "raw": "func = lambda energy_list, mage_id_list, npe_tot: True",
+    "mul": "func = lambda energy_list, mage_id_list, npe_tot: len(energy_list)==1",
+    "lar": "func = lambda energy_list, mage_id_list, npe_tot: npe_tot == 0",
+    "mul_lar": "func = lambda energy_list, mage_id_list, npe_tot: npe_tot == 0 and len(energy_list)==1"
+  }
 }

--- a/scripts/build_pdf_config.json
+++ b/scripts/build_pdf_config.json
@@ -1,0 +1,15 @@
+{
+    "energy_threshold": 0.025,
+    "hist": {
+        "nbins": 3000,
+        "bin_width": 1,
+        "emin": 0,
+        "emax": 3000
+    },
+    "cuts": {
+        "raw":      "func = lambda energy_list, mage_id_list, npe_tot: True",
+        "mul":      "func = lambda energy_list, mage_id_list, npe_tot: len(energy_list)==1",
+        "lar":      "func = lambda energy_list, mage_id_list, npe_tot: npe_tot == 0",
+        "mul_lar" : "func = lambda energy_list, mage_id_list, npe_tot: npe_tot == 0 and len(energy_list)==1"
+    }
+}


### PR DESCRIPTION
I have tested this build_pdf.py script on a map file supplied by Ian.

There are some things that we can maybe add if necessary in a config file as an argument (e.g energy bin width, no. bins, mpp field names). Right now it is all hard coded.

I have put in temporary names for now. The app file has a mage_id which I convert to the ged name and rawid. The structure of the output root file is:
- raw
- mul
- lar
- mul_raw

In each is a histogram for each channel (labelled by the rawid e.g ch1XXXXX) for the energy deposited in the ged given the cut criteria (e.g multiplicity ==1). Also the grouped histograms for each ged type (e.g type_coax) and a hist for all channels (simply called all). Thus one can grab a hist out of the output file by file.Get('raw').Get('ch1XXXXXX').

The cut criteria are:
- multiplicity == 1: event only has one ged energy deposit (i.e len(vector)==1)
- lar: in event npe_tot == 0
- mul_lar: combine above


You can find an example output pdf.root file at lngs at /data1/users/wquinn/build_pdf/evt_LGND_200_Baseline_Calibration_wSourceNumber_44_Height_124mm_pdf.root

