### PR TITLE
Build pdf

### DIFF
--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -93,6 +93,10 @@ hists = {
 
 for file_name in args.input_files:
     with uproot.open(f"{file_name}:simTree") as pytree:
+        if pytree.num_entries == 0:
+            msg = f">> Error: MPP evt file {file_name} has 0 events in simTree"
+            raise Exception(msg)
+
         n_primaries = pytree["mage_n_events"].array()[0]
         df_data = pd.DataFrame(
             pytree.arrays(["energy", "npe_tot", "mage_id", "is_good"], library="np")

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -117,7 +117,7 @@ for file_name in args.input_files:
         # Include them in the dataset then apply cuts - then filter them out
         # Don't store AC detectors
         exec(_cut_string)
-        df_good = df_cut[df_cut.is_good is True]
+        df_good = df_cut[df_cut.is_good == True]  # noqa: E712
         for _energy, _mage_id in zip(
             df_good.energy.to_numpy(), df_good.mage_id.to_numpy()
         ):

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -43,7 +43,7 @@ def process_mage_id(mage_ids):
             if _meta_dict["system"] == "geds":
                 location = _meta_dict["location"]
                 if location["string"] == string and location["position"] == pos:
-                    mage_names[f"ch{_meta_dict['daq']['rawid']}"] = _mage_id
+                    mage_names[_mage_id] = f"ch{_meta_dict['daq']['rawid']}"
 
     return mage_names
 
@@ -113,20 +113,23 @@ for file_name in args.input_files:
     # out_file["number_of_primaries"] = str(n_primaries)
 
     for _cut_name, _cut_string in rconfig["cuts"].items():
-        print(_cut_name)
         # We want to cut on multiplicity for all detectors >25keV
         # Include them in the dataset then apply cuts - then filter them out
         # Don't store AC detectors
         exec(_cut_string)
         df_good = df_cut[df_cut.is_good is True]
-
-        # loop over the geds in the file
+        for _energy, _mage_id in zip(
+            df_good.energy.to_numpy(), df_good.mage_id.to_numpy()
+        ):
+            _rawid = mage_names[_mage_id]
+            hists[_cut_name][_rawid].Fill(_energy * 1000)
+        """# loop over the geds in the file
         for _rawid, _mage_id in mage_names.items():
             df_channel = df_good[(df_good.mage_id == _mage_id)]
 
             # As detectors may change from ac to on in the data - loop through and cut
             for _energy in df_channel.energy.to_numpy():
-                hists[_cut_name][_rawid].Fill(_energy * 1000)  # energy in keV
+                hists[_cut_name][_rawid].Fill(_energy * 1000)  # energy in keV"""
 
 # The individual channels have been filled
 # now add them together to make the grouped hists

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -92,7 +92,6 @@ hists = {
 }
 
 for file_name in args.input_files:
-    print(file_name)
     with uproot.open(f"{file_name}:simTree") as pytree:
         if pytree.num_entries == 0:
             msg = f">> Error: MPP evt file {file_name} has 0 events in simTree"

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -92,6 +92,7 @@ hists = {
 }
 
 for file_name in args.input_files:
+    print(file_name)
     with uproot.open(f"{file_name}:simTree") as pytree:
         if pytree.num_entries == 0:
             msg = f">> Error: MPP evt file {file_name} has 0 events in simTree"
@@ -123,13 +124,6 @@ for file_name in args.input_files:
         ):
             _rawid = mage_names[_mage_id]
             hists[_cut_name][_rawid].Fill(_energy * 1000)
-        """# loop over the geds in the file
-        for _rawid, _mage_id in mage_names.items():
-            df_channel = df_good[(df_good.mage_id == _mage_id)]
-
-            # As detectors may change from ac to on in the data - loop through and cut
-            for _energy in df_channel.energy.to_numpy():
-                hists[_cut_name][_rawid].Fill(_energy * 1000)  # energy in keV"""
 
 # The individual channels have been filled
 # now add them together to make the grouped hists


### PR DESCRIPTION
A few bug fixes.

Realised the .explode().explode() lead to double counting i.e if an event had 4 entries then this would be counted 8 times. Changed to .explode(["" blah]) fixes this.

Use the is_good branch. Only use the metadata to get the mappings of string position to detector name and rawid (mage_id is based on string position). The is_good then defines whether or not to fill the hists for that detector and nothing more (so AC gets considered for multiplicity cuts).

Added the first Exception - there should be more but I will add later.

tested on 2vbb files, should really be tested on something like K40