### PR TITLE
Change to build_pdf handling of M2 categories

### DIFF
--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -360,8 +360,8 @@ for _cut_name, _hist_dict in hists.items():
 for dict in [sum_hists, hists_2d]:
     for _cut_name, _hist in dict.items():
         dir = out_file.mkdir(_cut_name)
-        if _hist.GetEntries() > 0:
-            dir["all"] = _hist
+        dir["all"] = _hist
+        
 print("INFO: nprimaries", n_primaries_total)
 out_file["number_of_primaries"] = str(int(n_primaries_total))
 out_file.close()

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -87,7 +87,8 @@ def get_m2_categories(channel_array, channel_to_string, channel_to_position):
     category = 1 * is_cat_one + 2 * is_cat_two + 3 * is_cat_three
     return np.array(category)
 
-def get_string_row_diff(channel_array,channel2string,channel2position):
+
+def get_string_row_diff(channel_array, channel2string, channel2position):
     """
     Get the categories for the m2 data based on 3 categories (should be in the cfg)
     1) Same string vertical neighbour
@@ -100,25 +101,24 @@ def get_string_row_diff(channel_array,channel2string,channel2position):
     Returns:
         categories: list of categories per event
     """
-    
-    channel_array=np.vstack(channel_array)
-    channel_one = channel_array[:,0].T
-    channel_two=channel_array[:,1].T
-    
-    
+
+    channel_array = np.vstack(channel_array)
+    channel_one = channel_array[:, 0].T
+    channel_two = channel_array[:, 1].T
+
     ## convert to the list of strings
-    string_one=channel2string(channel_one)
-    string_two=channel2string(channel_two)
-    string_diff_1= (string_one-string_two)%11
-    string_diff_2= (-string_one+string_two)%11
+    string_one = channel2string(channel_one)
+    string_two = channel2string(channel_two)
+    string_diff_1 = (string_one - string_two) % 11
+    string_diff_2 = (-string_one + string_two) % 11
     string_diff = np.array([min(a, b) for a, b in zip(string_diff_1, string_diff_2)])
-   
-    position_one=channel2position(channel_one)
-    position_two=channel2position(channel_two)
 
-    floor_diff = np.abs(position_one-position_two)
+    position_one = channel2position(channel_one)
+    position_two = channel2position(channel_two)
 
-    return np.array(string_diff),np.array(floor_diff)
+    floor_diff = np.abs(position_one - position_two)
+
+    return np.array(string_diff), np.array(floor_diff)
 
 
 def get_vectorised_converter(mapping):
@@ -149,7 +149,7 @@ parser.add_argument(
 )
 parser.add_argument("--config", "-c", required=True, help="configuration file")
 parser.add_argument("--output", "-o", required=True, help="output file name")
-parser.add_argument("--metadata", "-m",required=True, help="path to legend-metadata")
+parser.add_argument("--metadata", "-m", required=True, help="path to legend-metadata")
 parser.add_argument("input_files", nargs="+", help="evt tier files")
 
 args = parser.parse_args()
@@ -173,12 +173,12 @@ geds_mapping = {
     for _name, _dict in chmap.items()
     if chmap[_name]["system"] == "geds"
 }
-geds_strings= {
+geds_strings = {
     f"ch{_dict['daq']['rawid']}": _dict["location"]["string"]
     for _name, _dict in chmap.items()
     if chmap[_name]["system"] == "geds"
 }
-geds_positions= {
+geds_positions = {
     f"ch{_dict['daq']['rawid']}": _dict["location"]["position"]
     for _name, _dict in chmap.items()
     if chmap[_name]["system"] == "geds"
@@ -218,39 +218,39 @@ hists = {
 
 # When we want to start summing the energy of events we have to treat them differently
 
-sum_hists={}
-hists_2d={}
+sum_hists = {}
+hists_2d = {}
 
 ## categories for m2
-string_diff=np.arange(7)
-floor_diff=np.arange(8)
-names_m2 =[f"sd_{item1}" for item1 in string_diff ]
-names_m2.extend(["all","cat_1","cat_2","cat_3"])
+string_diff = np.arange(7)
+floor_diff = np.arange(8)
+names_m2 = [f"sd_{item1}" for item1 in string_diff]
+names_m2.extend(["all", "cat_1", "cat_2", "cat_3"])
 
 for _cut_name in rconfig["cuts"]:
     if rconfig["cuts"][_cut_name]["is_sum"] is True:
-        sum_hists[_cut_name]={}
-        sum_hists[_cut_name]["all"]= ROOT.TH1F(
-                            f"{_cut_name}_all_summed",
-                            "summed energy deposits",
-                            rconfig["hist"]["nbins"],
-                            rconfig["hist"]["emin"],
-                            rconfig["hist"]["emax"],
-                    )
-    if rconfig["cuts"][_cut_name]["is_2d"] is True:
-        hists_2d[_cut_name]={}
-        
-        for cat in names_m2:
-            hists_2d[_cut_name][cat]=ROOT.TH2F(
-            f"{_cut_name}_{cat}_2d",
-            "energy deposits",
-            rconfig["hist"]["nbins"],
-            rconfig["hist"]["emin"],
-            rconfig["hist"]["emax"],
+        sum_hists[_cut_name] = {}
+        sum_hists[_cut_name]["all"] = ROOT.TH1F(
+            f"{_cut_name}_all_summed",
+            "summed energy deposits",
             rconfig["hist"]["nbins"],
             rconfig["hist"]["emin"],
             rconfig["hist"]["emax"],
         )
+    if rconfig["cuts"][_cut_name]["is_2d"] is True:
+        hists_2d[_cut_name] = {}
+
+        for cat in names_m2:
+            hists_2d[_cut_name][cat] = ROOT.TH2F(
+                f"{_cut_name}_{cat}_2d",
+                "energy deposits",
+                rconfig["hist"]["nbins"],
+                rconfig["hist"]["emin"],
+                rconfig["hist"]["emax"],
+                rconfig["hist"]["nbins"],
+                rconfig["hist"]["emin"],
+                rconfig["hist"]["emax"],
+            )
 
 for file_name in args.input_files:
     print("INFO: loading file", file_name)
@@ -273,11 +273,9 @@ for file_name in args.input_files:
     rng = np.random.default_rng()
     df_data["npe_tot_poisson"] = rng.poisson(df_data.npe_tot)
 
-
     # Data has awkward length lists per event
     # exploding gives a dataframe with multiple rows per event (event no. is the index)
     df_exploded = df_data.explode(["energy", "mage_id", "is_good"])
-
 
     # Doing this over and over again maybe slow
     chmap_mage = process_mage_id(
@@ -286,15 +284,12 @@ for file_name in args.input_files:
     channel_to_string = get_vectorised_converter(chmap_mage["string"])
     channel_to_position = get_vectorised_converter(chmap_mage["position"])
 
-
     # Apply the real energy cut for effetcive event reconstruction
     df_ecut = df_exploded.query(f"energy > {rconfig['energy_threshold']}")
-
 
     # These give you the multiplicity of events (and events not including AC detectors)
     index_counts = df_ecut.index.value_counts()
     index_counts_is_good = df_ecut.query("is_good == True").index.value_counts()
-
 
     # Add columns for configuration file cuts (NOTE: quite slow)
     df_ecut = df_ecut.copy()
@@ -304,7 +299,6 @@ for file_name in args.input_files:
     n_primaries_total += n_primaries
 
     for _cut_name, _cut_dict in rconfig["cuts"].items():
-
         # We want to cut on multiplicity for all detectors >25keV, even AC
         # Include them in the dataset then apply cuts - then filter them out
         # Don't store AC detectors
@@ -328,42 +322,47 @@ for file_name in args.input_files:
 
         ### 2d histos
         elif _cut_dict["is_2d"] is True:
-            
             _energy_1_array = (
-                    df_good.groupby(df_good.index).energy.max().to_numpy(dtype=float)
-                ) * 1000
+                df_good.groupby(df_good.index).energy.max().to_numpy(dtype=float)
+            ) * 1000
             _energy_2_array = (
-                    df_good.groupby(df_good.index).energy.min().to_numpy(dtype=float)
-                ) * 1000
+                df_good.groupby(df_good.index).energy.min().to_numpy(dtype=float)
+            ) * 1000
 
             _mult_channel_array = (
-                        df_good.groupby(df_good.index)
-                        .mage_id.apply(lambda x: x.to_numpy())
-                        .to_numpy()
-                    )
+                df_good.groupby(df_good.index)
+                .mage_id.apply(lambda x: x.to_numpy())
+                .to_numpy()
+            )
             ### loop over categories
             for name in names_m2:
-                
-                if name!="all":
-                   
-                    categories =get_m2_categories(_mult_channel_array,channel_to_string,channel_to_position)
-                    string_diff,floor_diff =get_string_row_diff(_mult_channel_array,channel_to_string,channel_to_position)
-                    
-                    if ("cat" in name):
-                        cat=int(name.split("_")[1])
-                        _energy_1_array_tmp=np.array(_energy_1_array)[np.where(categories==cat)[0]]
-                        _energy_2_array_tmp=np.array(_energy_2_array)[np.where(categories==cat)[0]]
-                        
-                    elif ("sd" in name):
-                        sd=int(name.split("_")[1])
-                        
-                        ids =np.where((string_diff==sd))[0]
-                        _energy_1_array_tmp=np.array(_energy_1_array)[ids]
-                        _energy_2_array_tmp=np.array(_energy_2_array)[ids]
+                if name != "all":
+                    categories = get_m2_categories(
+                        _mult_channel_array, channel_to_string, channel_to_position
+                    )
+                    string_diff, floor_diff = get_string_row_diff(
+                        _mult_channel_array, channel_to_string, channel_to_position
+                    )
+
+                    if "cat" in name:
+                        cat = int(name.split("_")[1])
+                        _energy_1_array_tmp = np.array(_energy_1_array)[
+                            np.where(categories == cat)[0]
+                        ]
+                        _energy_2_array_tmp = np.array(_energy_2_array)[
+                            np.where(categories == cat)[0]
+                        ]
+
+                    elif "sd" in name:
+                        sd = int(name.split("_")[1])
+
+                        ids = np.where(string_diff == sd)[0]
+                        _energy_1_array_tmp = np.array(_energy_1_array)[ids]
+                        _energy_2_array_tmp = np.array(_energy_2_array)[ids]
 
                 else:
-                    _energy_1_array_tmp=np.array(_energy_1_array)
-                    _energy_2_array_tmp=np.array(_energy_2_array)
+                    _energy_1_array_tmp = np.array(_energy_1_array)
+                    _energy_2_array_tmp = np.array(_energy_2_array)
 
                 if len(_energy_1_array_tmp) == 0:
                     continue
@@ -429,7 +428,7 @@ for dict in [sum_hists, hists_2d]:
     for _cut_name, _sub_dirs in dict.items():
         dir = out_file.mkdir(_cut_name)
 
-        for _sub_dir,_hist in _sub_dirs.items():
+        for _sub_dir, _hist in _sub_dirs.items():
             dir[_sub_dir] = _hist
 
 print("INFO: nprimaries", n_primaries_total)

--- a/scripts/build_pdf.py
+++ b/scripts/build_pdf.py
@@ -185,9 +185,6 @@ geds_positions= {
 }
 
 strings = np.sort([item[1] for item in geds_strings.items()])
-string2index = np.vectorize({element: index for index, element in enumerate(strings)}.get)
-channel2string = get_vectorised_converter(geds_strings)
-channel2position = get_vectorised_converter(geds_positions)
 
 n_primaries_total = 0
 


### PR DESCRIPTION
Change to how the M2 categories are handled.
- Empty histograms are now saved anyway (to prevent the fitter crashing)
-  M2 categories are now no-longer separate cuts (this should be faster), so that instead of having PDFs like "mul2_surv_2d_cat_1/all" you have "mul2_surv_2d/cat_1" etc.
- I also added some PDFs splitting by the difference in string number.